### PR TITLE
Add support for caption key under fig and table

### DIFF
--- a/src/generator/com/elovirta/pdf/tables.xsl
+++ b/src/generator/com/elovirta/pdf/tables.xsl
@@ -230,6 +230,11 @@
         </axsl:attribute-set>
       </xsl:if>
       <!-- table -->
+      <axsl:attribute-set name="table.title">
+        <xsl:call-template name="generate-attribute-set">
+          <xsl:with-param name="prefix" select="'style-table-caption'"/>
+        </xsl:call-template>
+      </axsl:attribute-set>
       <axsl:attribute-set name="table.tgroup">
         <xsl:call-template name="generate-attribute-set">
           <xsl:with-param name="prefix" select="'style-table'"/>

--- a/src/generator/com/elovirta/pdf/topic.xsl
+++ b/src/generator/com/elovirta/pdf/topic.xsl
@@ -247,6 +247,11 @@
           <xsl:with-param name="prefix" select="'style-fig'"/>
         </xsl:call-template>
       </axsl:attribute-set>
+      <axsl:attribute-set name="fig.title">
+        <xsl:call-template name="generate-attribute-set">
+          <xsl:with-param name="prefix" select="'style-fig-caption'"/>
+        </xsl:call-template>
+      </axsl:attribute-set>
     </axsl:stylesheet>
   </xsl:template>
 


### PR DESCRIPTION
Add support for `caption` key under `style-fig` and `style-table`.

```yaml
style:
  fig:
    caption:
      background-color: pink
      position: after
      number: document
  table:
    caption:
      background-color: yellow
      position: before
      number: chapter
```

Fixes #55