### PR TITLE
Fix duplicate 'filepath' attribute set generation

### DIFF
--- a/src/generator/com/elovirta/pdf/ui-domain.xsl
+++ b/src/generator/com/elovirta/pdf/ui-domain.xsl
@@ -21,7 +21,7 @@
   <xsl:template match=".[. instance of map(*)]" mode="attr">
     <axsl:stylesheet version="2.0">
       <xsl:call-template name="generate-namespace-node"/>
-      <xsl:for-each select="('uicontrol', 'wintitle', 'menucascade', 'shortcut', 'screen', 'filepath', 'filepath')">
+      <xsl:for-each select="('uicontrol', 'wintitle', 'menucascade', 'shortcut', 'screen', 'filepath')">
         <axsl:attribute-set name="{.}">
           <xsl:call-template name="generate-attribute-set">
             <xsl:with-param name="prefix" select="concat('style-', .)"/>


### PR DESCRIPTION
The duplication was apparently already present in the old version of the code. When the individual attribute sets were combined to the 'for-each' in 098785d, the redundant copy was replicated.

Signed-off-by: Roger Sheen <roger@infotexture.net>