### PR TITLE
Apply body line-height attribute to block elements (fix #105)

### DIFF
--- a/src/generator/com/elovirta/pdf/commons.xsl
+++ b/src/generator/com/elovirta/pdf/commons.xsl
@@ -184,7 +184,7 @@
       <axsl:attribute-set name="common.block">
         <xsl:call-template name="generate-attribute-set">
           <xsl:with-param name="prefix" select="'style-body'"/>
-          <xsl:with-param name="properties" select="$allProperties[not(. = ('start-indent', 'font-family', 'font-size', 'line-height'))]"/>
+          <xsl:with-param name="properties" select="$allProperties[not(. = ('start-indent', 'font-family', 'font-size'))]"/>
         </xsl:call-template>
       </axsl:attribute-set>
       <axsl:attribute-set name="common.title">


### PR DESCRIPTION
This fixes style/body/line-height in the theme to not have effect.