### PR TITLE
Use 1-6 levels consistently to only include topicrefs

### DIFF
--- a/src/generator/com/elovirta/pdf/commons.xsl
+++ b/src/generator/com/elovirta/pdf/commons.xsl
@@ -335,10 +335,10 @@
         <fo:block axsl:use-attribute-sets="topic">
           <!-- TODO: Replace with mode="commonattributes" -->
           <axsl:call-template name="commonattributes"/>
-          <axsl:variable name="level" as="xs:integer">
-            <axsl:apply-templates select="." mode="get-topic-level"/>
-          </axsl:variable>
-          <axsl:if test="$level eq 1">
+<!--          <axsl:variable name="level" as="xs:integer">-->
+<!--            <axsl:apply-templates select="." mode="get-topic-level"/>-->
+<!--          </axsl:variable>-->
+<!--          <axsl:if test="$level eq 1">-->
             <axsl:variable name="topicref"
                            select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]"
                            as="element()?"/>
@@ -358,7 +358,7 @@
 <!--              <axsl:with-param name="marker-class-name" select="'current-header'"/>-->
 <!--            </axsl:apply-templates>-->
             <fo:marker marker-class-name="current-header"/>
-          </axsl:if>
+<!--          </axsl:if>-->
           <axsl:apply-templates select="." mode="customTopicMarker"/>
 
           <axsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>
@@ -469,10 +469,10 @@
         <fo:block axsl:use-attribute-sets="topic">
           <!-- TODO: Replace with mode="commonattributes" -->
           <axsl:call-template name="commonattributes"/>
-          <axsl:variable name="level" as="xs:integer">
-            <axsl:apply-templates select="." mode="get-topic-level"/>
-          </axsl:variable>
-          <axsl:if test="$level eq 1">
+<!--          <axsl:variable name="level" as="xs:integer">-->
+<!--            <axsl:apply-templates select="." mode="get-topic-level"/>-->
+<!--          </axsl:variable>-->
+<!--          <axsl:if test="$level eq 1">-->
             <axsl:variable name="topicref"
                            select="key('map-id', ancestor-or-self::*[contains(@class, ' topic/topic ')][1]/@id)[1]"
                            as="element()?"/>
@@ -505,7 +505,7 @@
                 <axsl:with-param name="marker-class-name" select="'current-part'"/>
               </axsl:apply-templates>
             </axsl:if>
-          </axsl:if>
+<!--          </axsl:if>-->
           <axsl:apply-templates select="." mode="customTopicMarker"/>
 
           <axsl:apply-templates select="*[contains(@class,' topic/prolog ')]"/>

--- a/src/generator/com/elovirta/pdf/toc.xsl
+++ b/src/generator/com/elovirta/pdf/toc.xsl
@@ -69,7 +69,10 @@
         <axsl:param name="prefix" select="''" as="xs:string?"/>
         <axsl:for-each select="$currentNode">
           <axsl:variable name="topicref" select="key('map-id', @id)"/>
-          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')])"/>
+<!--          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')])"/>-->
+          <axsl:variable name="level" as="xs:integer">
+            <axsl:apply-templates select="." mode="get-topic-level"/>
+          </axsl:variable>
           <axsl:choose>
             <xsl:for-each select="'', 'part', 'chapter', 'appendix'">
               <xsl:variable name="prefix" select="."/>
@@ -87,7 +90,7 @@
               <xsl:if
                   test="$prefix = ('', 'part') and (some $key in map:keys($root) satisfies starts-with($key, 'style' || $key-prefix || '-toc-chapter'))">
                 <axsl:when
-                    test="$prefix eq '{$prefix}' and $level = (1, 2) and $topicref/self::*[contains(@class, ' bookmap/chapter ')]">
+                    test="$prefix eq '{$prefix}' (:and $level = (1, 2) :) and $topicref/self::*[contains(@class, ' bookmap/chapter ')]">
                   <fo:block axsl:use-attribute-sets="{$attribute-set-prefix}__toc__chapter__content">
                     <axsl:copy-of select="$tocItemContent"/>
                   </fo:block>
@@ -468,13 +471,13 @@
           </axsl:variable>
           <axsl:choose>
             <xsl:if test="map:contains($root, 'style-toc-part-start-indent')">
-              <axsl:when test="$level eq 0 and key('map-id', @id)/self::*[contains(@class, ' bookmap/part ')]">
+              <axsl:when test="(:$level eq 0 and:) key('map-id', @id)/self::*[contains(@class, ' bookmap/part ')]">
                 <axsl:value-of
                     select="concat(e:force-unit('{$root ?style-toc-part-start-indent}'), ' + ', $toc.text-indent)"/>
               </axsl:when>
             </xsl:if>
             <xsl:if test="map:contains($root, 'style-toc-chapter-start-indent')">
-              <axsl:when test="$level eq 1">
+              <axsl:when test="(:$level eq 0 and:) key('map-id', @id)/self::*[contains(@class, ' bookmap/chapter ')]">
                 <axsl:value-of
                     select="concat(e:force-unit('{$root ?style-toc-chapter-start-indent}'), ' + ', $toc.text-indent)"/>
               </axsl:when>
@@ -519,8 +522,17 @@
 
       <axsl:attribute-set name="__toc__indent__part">
         <axsl:attribute name="start-indent">
-          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')]) - 1"/>
+<!--          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')]) - 1"/>-->
+          <axsl:variable name="level" as="xs:integer">
+            <axsl:apply-templates select="." mode="get-topic-level"/>
+          </axsl:variable>
           <axsl:choose>
+            <xsl:if test="map:contains($root, 'style-part-toc-chapter-start-indent')">
+              <axsl:when test="(:$level eq 0 and:) key('map-id', @id)/self::*[contains(@class, ' bookmap/chapter ')]">
+                <axsl:value-of
+                    select="concat(e:force-unit('{$root ?style-part-toc-chapter-start-indent}'), ' + ', $toc.text-indent)"/>
+              </axsl:when>
+            </xsl:if>
             <xsl:for-each select="1 to 6">
               <xsl:variable name="level" select="."/>
               <xsl:if test="map:contains($root, 'style-part-toc-' || $level || '-start-indent')">
@@ -571,10 +583,13 @@
 
       <axsl:attribute-set name="__toc__indent__chapter">
         <axsl:attribute name="start-indent">
-          <axsl:variable name="inside-part" as="xs:boolean"
-                         select="exists(key('map-id', @id)/ancestor-or-self::*[contains(@class, ' bookmap/part ')])"/>
-          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')])
-                                              - (if ($inside-part) then 2 else 1)"/>
+<!--          <axsl:variable name="inside-part" as="xs:boolean"-->
+<!--                         select="exists(key('map-id', @id)/ancestor-or-self::*[contains(@class, ' bookmap/part ')])"/>-->
+<!--          <axsl:variable name="level" select="count(ancestor-or-self::*[contains(@class, ' topic/topic ')])-->
+<!--                                              - (if ($inside-part) then 1 else 0)"/>-->
+          <axsl:variable name="level" as="xs:integer">
+            <axsl:apply-templates select="." mode="get-topic-level"/>
+          </axsl:variable>
           <axsl:choose>
             <xsl:for-each select="1 to 6">
               <xsl:variable name="level" select="."/>
@@ -774,6 +789,13 @@
           </xsl:call-template>
         </axsl:attribute-set>
       </xsl:for-each>
+
+<!--      <axsl:attribute-set name="__part__toc__topic__content" use-attribute-sets="__toc__topic__content">-->
+        <!--          <xsl:call-template name="generate-attribute-set">-->
+        <!--            <xsl:with-param name="prefix" select="'style-' || $prefix || '-toc-1'"/>-->
+        <!--            <xsl:with-param name="properties" select="$allProperties[. ne 'start-indent']"/>-->
+        <!--          </xsl:call-template>-->
+<!--      </axsl:attribute-set>-->
 
       <xsl:for-each select="('part', 'chapter', 'appendix')">
         <xsl:variable name="prefix" select="."/>

--- a/src/generator/com/elovirta/pdf/topic.xsl
+++ b/src/generator/com/elovirta/pdf/topic.xsl
@@ -232,6 +232,121 @@
         </axsl:choose>
       </axsl:template>
 
+      <axsl:template match="*" mode="get-topic-level" as="xs:integer">
+        <axsl:variable name="topicref"
+                       select="key('map-id', ancestor-or-self::*[contains(@class,' topic/topic ')][1]/@id)[1]"
+                       as="element()?"
+        />
+        <axsl:sequence select="count(ancestor-or-self::*[contains(@class,' topic/topic ')]) -
+                          count($topicref/ancestor-or-self::*[(contains(@class, ' bookmap/part ') and
+                                                               ((exists(@navtitle) or *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/navtitle ')]) or
+                                                                (exists(@href) and
+                                                                 (empty(@format) or @format eq 'dita') and
+                                                                 (empty(@scope) or @scope eq 'local')))) or
+
+                                                              (contains(@class, ' bookmap/chapter ') and
+                                                               ((exists(@navtitle) or *[contains(@class,' map/topicmeta ')]/*[contains(@class,' topic/navtitle ')]) or
+                                                                (exists(@href) and
+                                                                 (empty(@format) or @format eq 'dita') and
+                                                                 (empty(@scope) or @scope eq 'local')))) or
+
+                                                              (contains(@class,' bookmap/appendices ') and
+                                                               exists(@href) and
+                                                               (empty(@format) or @format eq 'dita') and
+                                                               (empty(@scope) or @scope eq 'local'))])"/>
+      </axsl:template>
+
+<!--      <axsl:template match="*" mode="processTopicTitle">-->
+<!--        <axsl:variable name="level" as="xs:integer">-->
+<!--          <axsl:apply-templates select="." mode="get-topic-level"/>-->
+<!--        </axsl:variable>-->
+<!--        <axsl:variable name="attrSet1">-->
+<!--          <axsl:apply-templates select="." mode="createTopicAttrsName">-->
+<!--            <axsl:with-param name="theCounter" select="$level"/>-->
+<!--          </axsl:apply-templates>-->
+<!--        </axsl:variable>-->
+<!--        <fo:block>-->
+<!--          <axsl:call-template name="commonattributes"/>-->
+<!--          <axsl:call-template name="get-attributes">-->
+<!--            <axsl:with-param name="element" as="element()">-->
+<!--              <axsl:choose>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.topic.topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.topic.topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.topic.title'">-->
+<!--                  <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.topic.topic.title"/>-->
+<!--                </axsl:when>-->
+<!--                <axsl:otherwise>-->
+<!--                  <placeholder/>-->
+<!--                </axsl:otherwise>-->
+<!--              </axsl:choose>-->
+<!--            </axsl:with-param>-->
+<!--          </axsl:call-template>-->
+<!--          level=<axsl:value-of select="$level"/> attrSet1=<axsl:value-of select="$attrSet1"/>-->
+<!--          <fo:block>-->
+<!--            <axsl:call-template name="get-attributes">-->
+<!--              <axsl:with-param name="element" as="element()">-->
+<!--                <axsl:choose>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.topic.topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.topic.topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:when test="$attrSet1 = 'topic.topic.topic.topic.topic.topic.title'">-->
+<!--                    <placeholder axsl:use-attribute-sets="topic.topic.topic.topic.topic.topic.title__content"/>-->
+<!--                  </axsl:when>-->
+<!--                  <axsl:otherwise>-->
+<!--                    <placeholder/>-->
+<!--                  </axsl:otherwise>-->
+<!--                </axsl:choose>-->
+<!--              </axsl:with-param>-->
+<!--            </axsl:call-template>-->
+<!--            <axsl:if test="$level = 1">-->
+<!--              <axsl:apply-templates select="." mode="insertTopicHeaderMarker"/>-->
+<!--            </axsl:if>-->
+<!--            <axsl:if test="$level = 2">-->
+<!--              <axsl:apply-templates select="." mode="insertTopicHeaderMarker">-->
+<!--                <axsl:with-param name="marker-class-name" as="xs:string">current-h2</axsl:with-param>-->
+<!--              </axsl:apply-templates>-->
+<!--            </axsl:if>-->
+<!--            <fo:wrapper id="{{parent::node()/@id}}"/>-->
+<!--            <fo:wrapper>-->
+<!--              <axsl:attribute name="id">-->
+<!--                <axsl:call-template name="generate-toc-id">-->
+<!--                  <axsl:with-param name="element" select=".."/>-->
+<!--                </axsl:call-template>-->
+<!--              </axsl:attribute>-->
+<!--            </fo:wrapper>-->
+<!--            <axsl:apply-templates select="." mode="customTopicAnchor"/>-->
+<!--            <axsl:call-template name="pullPrologIndexTerms"/>-->
+<!--            <axsl:apply-templates select="preceding-sibling::*[contains(@class,' ditaot-d/ditaval-startprop ')]"/>-->
+<!--            <axsl:apply-templates select="." mode="getTitle"/>-->
+<!--          </fo:block>-->
+<!--        </fo:block>-->
+<!--      </axsl:template>-->
+
       <!-- note -->
       <axsl:template match="*[contains(@class,' topic/note ')]">
         <axsl:variable name="noteImagePath">

--- a/src/main/resources/com/elovirta/pdf/default.json
+++ b/src/main/resources/com/elovirta/pdf/default.json
@@ -108,27 +108,27 @@
           "font-size": "10pt"
         },
         "1": {
-          "start-indent": "0pt",
-          "title-numbering": true
-        },
-        "2": {
           "start-indent": "$brand-toc-indent",
           "title-numbering": true
         },
-        "3": {
-          "start-indent": "2 * $brand-toc-indent",
+        "2": {
+          "start-indent": "2* $brand-toc-indent",
           "title-numbering": true
         },
-        "4": {
+        "3": {
           "start-indent": "3 * $brand-toc-indent",
           "title-numbering": true
         },
-        "5": {
+        "4": {
           "start-indent": "4 * $brand-toc-indent",
           "title-numbering": true
         },
-        "6": {
+        "5": {
           "start-indent": "5 * $brand-toc-indent",
+          "title-numbering": true
+        },
+        "6": {
+          "start-indent": "6 * $brand-toc-indent",
           "title-numbering": true
         }
       }
@@ -154,27 +154,27 @@
         "font-size": "$style-toc-chapter-font-size"
       },
       "1": {
-        "start-indent": "0pt",
-        "title-numbering": true
-      },
-      "2": {
         "start-indent": "$brand-toc-indent",
         "title-numbering": true
       },
-      "3": {
+      "2": {
         "start-indent": "2 * $brand-toc-indent",
         "title-numbering": true
       },
-      "4": {
+      "3": {
         "start-indent": "3 * $brand-toc-indent",
         "title-numbering": true
       },
-      "5": {
+      "4": {
         "start-indent": "4 * $brand-toc-indent",
         "title-numbering": true
       },
-      "6": {
+      "5": {
         "start-indent": "5 * $brand-toc-indent",
+        "title-numbering": true
+      },
+      "6": {
+        "start-indent": "6 * $brand-toc-indent",
         "title-numbering": true
       }
     },


### PR DESCRIPTION
Use 1-6 levels consistently to only include topicrefs. Part and chapter need to be styled separately and are not included in 1-6 levels.